### PR TITLE
add git-link-open-in-browser variable to optionally also open in browser

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -47,7 +47,7 @@
 
 (defvar git-link-default-remote "origin" "Name of the remote branch to link to")
 
-(defcustom git-link-open-in-browser nil "If non-nil, also open link in browser")
+(defvar git-link-open-in-browser nil "If non-nil, also open link in browser")
 
 (defvar git-link-remote-alist
   '(("github.com"    git-link-github)


### PR DESCRIPTION
similar to dolzenko/git-link@8bdf9683e6170d8b12fbf123a17e229b447150c8
