### PR TITLE
Change git-link-current-branch match logic

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -81,9 +81,9 @@
   (git-link-exec "--no-pager" "log" "-n1" "--pretty=format:%H"))
 
 (defun git-link-current-branch ()
-  (let ((branch (git-link-exec "symbolic-ref" "HEAD")))
-      (if (string-match "/\\([^/]+?\\)$" branch)
-	  (match-string 1 branch))))
+  (let ((branch (git-link-exec "symbolic-ref" "--short" "HEAD")))
+    (if (string-match "\\(.*\\)$" branch)
+        (match-string 1 branch))))
 
 (defun git-link-repo-root ()
   (git-link-chomp (git-link-exec "rev-parse" "--show-toplevel")))


### PR DESCRIPTION
We have git branch names that include slashes. This alternate method of extracting the current branch name allows git-link to work on these branches.
