### PR TITLE
Use remote hostname when constructing link URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ can configure the link function alists for the hostname at which that
 service is hosted.  For example, for a GitHub Enterprise instance at
 `github.example.com`, you could add the following to your `.emacs` file.
 
-    (with-eval-after-load "git-link"
-      (progn
-	(add-to-list 'git-link-remote-alist
-	  '("github.example.com" git-link-github))
-	(add-to-list 'git-link-commit-remote-alist
-	  '("github.example.com" git-link-commit-github))))
+    (eval-after-load "git-link"
+      '(progn
+        (add-to-list 'git-link-remote-alist
+          '("github.example.com" git-link-github))
+        (add-to-list 'git-link-commit-remote-alist
+          '("github.example.com" git-link-commit-github))))
 
 The `git-link` signature is:
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ hostnames to a function capable of creating a URL on that host. To add (or
 modify) how URLs are created for a given host add the appropriate function
 objects to this lists.
 
+If you use a self-hosted version of one of the supported services, you
+can configure the link function alists for the hostname at which that
+service is hosted.  For example, for a GitHub Enterprise instance at
+`github.example.com`, you could add the following to your `.emacs` file.
+
+    (with-eval-after-load "git-link"
+      (progn
+	(add-to-list 'git-link-remote-alist
+	  '("github.example.com" git-link-github))
+	(add-to-list 'git-link-commit-remote-alist
+	  '("github.example.com" git-link-commit-github))))
+
 The `git-link` signature is:
 
 `HOSTNAME DIRNAME FILENAME BRANCH COMMIT START END`

--- a/git-link.el
+++ b/git-link.el
@@ -134,7 +134,8 @@
          (when use-region (line-number-at-pos (region-end))))))))
 
 (defun git-link-github (hostname dirname filename branch commit start end)
-  (format "https://github.com/%s/tree/%s/%s#%s"
+  (format "https://%s/%s/tree/%s/%s#%s"
+	  hostname
 	  dirname
 	  (or branch commit)
 	  filename
@@ -143,25 +144,29 @@
 	    (format "L%s" start))))
 
 (defun git-link-commit-github (hostname dirname commit)
-  (format "https://github.com/%s/commit/%s"
+  (format "https://%s/%s/commit/%s"
+	  hostname
 	  dirname
 	  commit))
 
 (defun git-link-gitorious (hostname dirname filename branch commit start end)
-  (format "https://gitorious.org/%s/source/%s:%s#L%s"
+  (format "https://%s/%s/source/%s:%s#L%s"
+	  hostname
 	  dirname
 	  commit
 	  filename
 	  start))
 
 (defun git-link-commit-gitorious (hostname dirname commit)
-  (format "https://gitorious.org/%s/commit/%s"
+  (format "https://%s/%s/commit/%s"
+	  hostname
 	  dirname
 	  commit))
 
 (defun git-link-bitbucket (hostname dirname filename branch commit start end)
   ;; ?at=branch-name
-  (format "https://bitbucket.org/%s/src/%s/%s#cl-%s"
+  (format "https://%s/%s/src/%s/%s#cl-%s"
+	  hostname
 	  dirname
 	  commit
 	  filename
@@ -169,7 +174,8 @@
 
 (defun git-link-commit-bitbucket (hostname dirname commit)
   ;; ?at=branch-name
-  (format "https://bitbucket.org/%s/commits/%s"
+  (format "https://%s/%s/commits/%s"
+	  hostname
 	  dirname
 	  commit))
 


### PR DESCRIPTION
GitHub, Gitorious, and Bitbucket each have self-hosted versions (GitHub
Enterprise, Gitorious open source, and Atlassian Stash).  Update the
link-creation functions so that they use the remote hostname to contruct
the link URL instead of hardcoding each company's hostname so that the
link functions can be used to contruct URLs for the self-hosted versions
of the products.