### PR TITLE
Add support for gitlab.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # git-link
 
 Interactive Emacs functions that create URLs for files and commits in
-GitHub/Bitbucket/Gitorious/... repositories. `git-link` returns the URL for the
-current buffer's file location at the current line number or active region.
-`git-link-commit` returns the URL for a commit. URLs are added to the kill ring.
+GitHub/Bitbucket/Gitorious/GitLab/... repositories. `git-link` returns the URL
+for the current buffer's file location at the current line number or active
+region.  `git-link-commit` returns the URL for a commit. URLs are added to the
+kill ring.
 
 ## Usage
 
@@ -30,6 +31,7 @@ If non-`nil` use the latest commit's hash in the link instead of the branch name
 * [Bitbucket](http://bitbucket.com)
 * [GitHub](http://github.com)
 * [Gitorious](http://gitorious.org)
+* [GitLab](https://gitlab.com)
 
 ### Building Links and Adding Services
 

--- a/git-link.el
+++ b/git-link.el
@@ -65,13 +65,15 @@
 (defvar git-link-remote-alist
   '(("github.com"    git-link-github)
     ("bitbucket.org" git-link-bitbucket)
-    ("gitorious.org" git-link-gitorious))
+    ("gitorious.org" git-link-gitorious)
+    ("gitlab.com"    git-link-github))
   "Maps remote hostnames to a function capable of creating the appropriate file URL")
 
 (defvar git-link-commit-remote-alist
   '(("github.com"    git-link-commit-github)
     ("bitbucket.org" git-link-commit-bitbucket)
-    ("gitorious.org" git-link-commit-gitorious))
+    ("gitorious.org" git-link-commit-gitorious)
+    ("gitlab.com"    git-link-commit-github))
   "Maps remote hostnames to a function capable of creating the appropriate commit URL")
 
 ;; Matches traditional URL and scp style
@@ -146,7 +148,7 @@
          (when use-region (line-number-at-pos (region-end))))))))
 
 (defun git-link-github (hostname dirname filename branch commit start end)
-  (format "https://%s/%s/tree/%s/%s#%s"
+  (format "https://%s/%s/blob/%s/%s#%s"
 	  hostname
 	  dirname
 	  (or branch commit)


### PR DESCRIPTION
Please note that GitLab is unabashedly compatible with GitHub, so it is easy to use the same GitHub functions for GitLab.