### PR TITLE
Add optional remote-host mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ The `git-link-commit` signature is:
 * `DIRNAME` directory portion of the remote
 * `COMMIT` SHA of the commit
 
+If you use Gerrit with replication enabled to a supported service,
+you can redirect by adding the following to your `.emacs` file.
+
+    (eval-after-load "git-link"
+      '(progn
+        (add-to-list 'git-link-remote-host-alist
+          '("gerrit.example.com" "gitlab.example.com/org-name"))
+        (add-to-list 'git-link-remote-alist
+          '("gitlab.example.com/org-name" git-link-github))
+        (add-to-list 'git-link-commit-remote-alist
+          '("gitlab.example.com/org-name" git-link-commit-github))))
+
 ### TODO
 
 * Consolidate `git-link-*-alist`s

--- a/git-link.el
+++ b/git-link.el
@@ -55,6 +55,7 @@
 ;;; Code:
 
 (require 'thingatpt)
+(require 'url-parse)
 
 (defvar git-link-default-remote "origin"
   "Name of the remote branch to link to.")
@@ -79,9 +80,9 @@
     ("gitlab.com"    git-link-commit-github))
   "Maps remote hostnames to a function capable of creating the appropriate commit URL")
 
-;; Matches traditional URL and scp style
-;; This probably wont work for git remotes that aren't services
-(defconst git-link-remote-regex "\\([-.[:word:]]+\\)[:/]\\([^/]+/[^/]+?\\)\\(?:\\.git\\)?$")
+(defvar git-link-remote-host-alist
+  nil
+  "Maps git remote hostnames to a link hostname.")
 
 (defun git-link-chomp (s)
   (if (string-match "\\(\r?\n\\)+$" s)
@@ -114,14 +115,14 @@
 		   (1+ (length dir))))))
 
 (defun git-link-remote-host (remote-name)
-  (let ((url (git-link-remote-url remote-name)))
-    (if (string-match git-link-remote-regex url)
-	(match-string 1 url))))
+  (let ((url (url-generic-parse-url (git-link-remote-url remote-name))))
+    (let ((host (url-host url)))
+      (or (cadr (assoc host git-link-remote-host-alist))
+          host))))
 
 (defun git-link-remote-dir (remote-name)
-  (let ((url (git-link-remote-url remote-name)))
-    (if (string-match git-link-remote-regex url)
-        (match-string 2 url))))
+  (let ((url (url-generic-parse-url (git-link-remote-url remote-name))))
+    (substring (file-name-sans-extension (url-filename url)) 1)))
 
 (defun git-link-remotes ()
   "Returns the list of remotes for this repository, or nil on error"


### PR DESCRIPTION
When using gerrit, the git remote url looks something like:
 "ssh://username@gerrit.example.com:29418/project-name"

It is common to have gerrit replicate to github or gitlab, this change
makes it possible to add this mapping from gerrit host to another such
service.  For example, mapping the above url to:
 "https://gitlab.example.com/org-name/project-name"

Changed the url regex to use url-parse, since the port was being
included as part of the path.