### PR TITLE
git-link-new errors on call to message if interprogram-cut-function is set

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -212,7 +212,8 @@
 	  commit))
 
 (defun git-link-new (link)
-  (message (kill-new link))
+  (kill-new link)
+  (message link)
   (setq deactivate-mark t)
   (when git-link-open-in-browser
     (browse-url link)))


### PR DESCRIPTION
If `interprogram-cut-function` is set (for example, OSX users often set this to invoke `pbcopy`) `kill-new` may return a proc instead of a string, causing `message` to error. Calling `message` directly on `link` should be safer.
