### PR TITLE
GitHub fix

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -70,7 +70,7 @@
   '(("github.com"    git-link-github)
     ("bitbucket.org" git-link-bitbucket)
     ("gitorious.org" git-link-gitorious)
-    ("gitlab.com"    git-link-github))
+    ("gitlab.com"    git-link-gitlab))
   "Maps remote hostnames to a function capable of creating the appropriate file URL")
 
 (defvar git-link-commit-remote-alist
@@ -166,7 +166,17 @@
             (setq line-end nil)))
         (list line-start line-end)))))
 
-(defun git-link-github (hostname dirname filename branch commit start end)
+(defun git-link-gitlab (hostname dirname filename branch commit start end)
+  (format "https://%s/%s/blob/%s/%s#%s"
+	  hostname
+	  dirname
+	  (or branch commit)
+	  filename
+	  (if (and start end)
+	      (format "L%s-%s" start end)
+	    (format "L%s" start))))
+
+(defun git-link-gitlab (hostname dirname filename branch commit start end)
   (format "https://%s/%s/blob/%s/%s#%s"
 	  hostname
 	  dirname

--- a/git-link.el
+++ b/git-link.el
@@ -176,7 +176,7 @@
 	      (format "L%s-%s" start end)
 	    (format "L%s" start))))
 
-(defun git-link-gitlab (hostname dirname filename branch commit start end)
+(defun git-link-github (hostname dirname filename branch commit start end)
   (format "https://%s/%s/blob/%s/%s#%s"
 	  hostname
 	  dirname


### PR DESCRIPTION
Hi guys! Finally I found what I was looking for. I've a custom gitlab repository and now finally I can get the link to the repo!

I've noticed that when selecting a region the generated link was wrong, it was using the github format: `#L1-L24` while gitlab does not want the last L, so the correct format is `#L1-24`. So here a pull request for you! :)