### PR TITLE
Support orgmode org

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -90,7 +90,8 @@ word under point is not a valid commit hash.")
     ("bitbucket.org"        git-link-bitbucket)
     ("gitorious.org"        git-link-gitorious)
     ("gitlab.com"           git-link-gitlab)
-    ("git.savannah.gnu.org" git-link-savannah-gnu))
+    ("git.savannah.gnu.org" git-link-savannah-gnu)
+    ("orgmode.org"          git-link-org-mode))
   "Maps remote hostnames to a function capable of creating the appropriate file URL")
 
 (defvar git-link-commit-remote-alist
@@ -98,12 +99,13 @@ word under point is not a valid commit hash.")
     ("bitbucket.org"        git-link-commit-bitbucket)
     ("gitorious.org"        git-link-commit-gitorious)
     ("gitlab.com"           git-link-commit-github)
-    ("git.savannah.gnu.org" git-link-commit-savannah-gnu))
+    ("git.savannah.gnu.org" git-link-commit-savannah-gnu)
+    ("orgmode.org"          git-link-commit-org-mode))
   "Maps remote hostnames to a function capable of creating the appropriate commit URL")
 
 ;; Matches traditional URL and scp style
 ;; This probably wont work for git remotes that aren't services
-(defconst git-link-remote-regex "\\([-.[:word:]]+\\)[:/]\\([^/]+/[^/]+?\\)\\(?:\\.git\\)?$")
+(defconst git-link-remote-regex "\\([-.[:word:]]+\\)[:/]\\([^/]+\\(/[^/]+?\\)*\\)\\(?:\\.git\\)?$")
 
 (defun git-link--last-commit ()
   (car (git-link--exec "--no-pager" "log" "-n1" "--pretty=format:%H")))
@@ -261,6 +263,20 @@ word under point is not a valid commit hash.")
 
 (defun git-link-commit-savannah-gnu (hostname dirname commit)
   (format "http://%s/cgit/%s/commit/?id=%s"
+          hostname
+          (replace-regexp-in-string "^r/\\(.*\\)" "\\1.git" dirname)
+          commit))
+
+(defun git-link-org-mode (hostname dirname filename branch commit start end)
+  (format "http://%s/cgit.cgi/%s/tree/%s?id=%s#n%s"
+          hostname
+          (replace-regexp-in-string "^r/\\(.*\\)" "\\1.git" dirname)
+          filename
+          commit
+          start))
+
+(defun git-link-commit-org-mode (hostname dirname commit)
+  (format "http://%s/cgit.cgi/%s/commit/?id=%s"
           hostname
           (replace-regexp-in-string "^r/\\(.*\\)" "\\1.git" dirname)
           commit))

--- a/git-link.el
+++ b/git-link.el
@@ -86,17 +86,19 @@
 word under point is not a valid commit hash.")
 
 (defvar git-link-remote-alist
-  '(("github.com"    git-link-github)
-    ("bitbucket.org" git-link-bitbucket)
-    ("gitorious.org" git-link-gitorious)
-    ("gitlab.com"    git-link-gitlab))
+  '(("github.com"           git-link-github)
+    ("bitbucket.org"        git-link-bitbucket)
+    ("gitorious.org"        git-link-gitorious)
+    ("gitlab.com"           git-link-gitlab)
+    ("git.savannah.gnu.org" git-link-savannah-gnu))
   "Maps remote hostnames to a function capable of creating the appropriate file URL")
 
 (defvar git-link-commit-remote-alist
-  '(("github.com"    git-link-commit-github)
-    ("bitbucket.org" git-link-commit-bitbucket)
-    ("gitorious.org" git-link-commit-gitorious)
-    ("gitlab.com"    git-link-commit-github))
+  '(("github.com"           git-link-commit-github)
+    ("bitbucket.org"        git-link-commit-bitbucket)
+    ("gitorious.org"        git-link-commit-gitorious)
+    ("gitlab.com"           git-link-commit-github)
+    ("git.savannah.gnu.org" git-link-commit-savannah-gnu))
   "Maps remote hostnames to a function capable of creating the appropriate commit URL")
 
 ;; Matches traditional URL and scp style
@@ -248,6 +250,20 @@ word under point is not a valid commit hash.")
 	  hostname
 	  dirname
 	  commit))
+
+(defun git-link-savannah-gnu (hostname dirname filename branch commit start end)
+  (format "http://%s/cgit/%s/tree/%s?id=%s#n%s"
+          hostname
+          (replace-regexp-in-string "^r/\\(.*\\)" "\\1.git" dirname)
+          filename
+          commit
+          start))
+
+(defun git-link-commit-savannah-gnu (hostname dirname commit)
+  (format "http://%s/cgit/%s/commit/?id=%s"
+          hostname
+          (replace-regexp-in-string "^r/\\(.*\\)" "\\1.git" dirname)
+          commit))
 
 ;;;###autoload
 (defun git-link (remote start end)


### PR DESCRIPTION
Support the org-mode source code git

The git-link-remote-regex had to be fixed to support links like
http://orgmode.org/org-mode.git

Note that earlier regexp expected 2 forward slashes in the path, like
http://git.savannah.gnu.org/r/emacs.git

Now the second forward slash part is put into an optional regexp
sub-group "\(/[^/]+?\)*"
