### PR TITLE
Added git-link-latest-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ kill ring.
 
 ## Usage
 
-`M-x git-link` and `M-x git-link-commit`
+`M-x git-link`, `M-x git-link-commit`, and `M-x git-link-latest-commit`
 
 With a prefix argument prompt for the remote's name. Defaults to `"origin"`.
 
@@ -98,6 +98,8 @@ The `git-link-commit` signature is:
 * `HOSTNAME` hostname of the remote
 * `DIRNAME` directory portion of the remote
 * `COMMIT` SHA of the commit
+
+The `git-link-latest-commit` signature is the same as `git-link-commit`
 
 ### TODO
 

--- a/git-link.el
+++ b/git-link.el
@@ -337,5 +337,32 @@ Defaults to \"origin\"."
 		     (git-link--remote-dir remote)
 		     commit))))))
 
+;;;###autoload
+(defun git-link-latest-commit (remote)
+  "Create a URL representing the latest commit in the current
+buffer's Github/Bitbucket/Gitorious/... repository. The URL
+will be added to the kill ring
+
+With a prefix argument prompt for the remote's name.
+Defaults to \"origin\"."
+  (interactive (list (if current-prefix-arg
+                         (git-link--read-remote)
+                       (git-link--remote))))
+  (let* ((remote-host (git-link--remote-host remote))
+         (commit      (git-link--last-commit))
+         (handler     (cadr (assoc remote-host git-link-commit-remote-alist))))
+    (cond ((null remote-host)
+           (message "Remote '%s' is unknown or contains an unsupported URL" remote))
+          ((not (string-match "[a-z0-9]\\{7,40\\}" (or commit "")))
+           (message "Point is not on a commit hash"))
+          ((not (functionp handler))
+           (message "No handler for %s" remote-host))
+          ;; null ret val
+          ((git-link--new
+            (funcall handler
+                     remote-host
+                     (git-link--remote-dir remote)
+                     commit))))))
+
 (provide 'git-link)
 ;;; git-link.el ends here


### PR DESCRIPTION
Rationale: My code review workflow where I work requires that we provide
a link to a single commit for each change we make. That means you make
the change, commit it, push it up to your dev branch, and then add a
link of the commit to the code review.

I couldn't find anywhere in magit that automatically displays the hash
of the latest commit. This function allows me to simply get a link to
the latest commit copied to my kill-ring (and therefore my system
clipboard).

Implementation: I tried to follow exactly the conventions already
established. The only change from git-link-commit is that we use the
`(git-link-last-commit)` to get the commit hash.