### PR TITLE
Add savannah.gnu.org (cgit) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Name of the remote branch to link to.
 * [Bitbucket](http://bitbucket.com)
 * [GitHub](http://github.com)
 * [GitLab](https://gitlab.com)
+* [Savannah](http://savannah.gnu.org)
 
 ### Building Links and Adding Services
 

--- a/git-link.el
+++ b/git-link.el
@@ -90,22 +90,24 @@
   "If non-nil use the latest commit's hash in the link instead of the branch name.")
 
 (defvar git-link-remote-alist
-  '(("github.com"    git-link-github)
-    ("bitbucket.org" git-link-bitbucket)
-    ("gitorious.org" git-link-gitorious)
-    ("gitlab.com"    git-link-gitlab))
+  '(("github.com"           git-link-github)
+    ("bitbucket.org"        git-link-bitbucket)
+    ("gitorious.org"        git-link-gitorious)
+    ("gitlab.com"           git-link-gitlab)
+    ("git.savannah.gnu.org" git-link-cgit))
   "Maps remote hostnames to a function capable of creating the appropriate file URL")
 
 (defvar git-link-commit-remote-alist
-  '(("github.com"    git-link-commit-github)
-    ("bitbucket.org" git-link-commit-bitbucket)
-    ("gitorious.org" git-link-commit-gitorious)
-    ("gitlab.com"    git-link-commit-github))
+  '(("github.com"           git-link-commit-github)
+    ("bitbucket.org"        git-link-commit-bitbucket)
+    ("gitorious.org"        git-link-commit-gitorious)
+    ("gitlab.com"           git-link-commit-github)
+    ("git.savannah.gnu.org" git-link-commit-cgit))
   "Maps remote hostnames to a function capable of creating the appropriate commit URL")
 
 ;; Matches traditional URL and scp style
 ;; This probably wont work for git remotes that aren't services
-(defconst git-link-remote-regex "\\([-.[:word:]]+\\)[:/]\\([^/]+/[^/]+?\\)\\(?:\\.git\\)?$")
+(defconst git-link-remote-regex "\\([-.[:word:]]+\\)[:/]\\([^/.]+\\(?:/[^/.]+\\)?\\)\\(?:\\.git\\)?$")
 
 (defun git-link--exec(&rest args)
   (ignore-errors (apply 'process-lines `("git" ,@(when args args)))))
@@ -269,6 +271,20 @@
 (defun git-link-commit-bitbucket (hostname dirname commit)
   ;; ?at=branch-name
   (format "https://%s/%s/commits/%s"
+	  hostname
+	  dirname
+	  commit))
+
+(defun git-link-cgit (hostname dirname filename branch commit start end)
+  (format "http://%s/cgit/%s.git/tree/%s?id=%s#n%s"
+	  hostname
+	  dirname
+	  filename
+	  commit
+	  start))
+
+(defun git-link-commit-cgit (hostname dirname commit)
+  (format "http://%s/cgit/%s.git/commit/?id=%s"
 	  hostname
 	  dirname
 	  commit))


### PR DESCRIPTION
The main difference is the modification in [`git-link-remote-regex`](https://github.com/itorresgit-link/blob/add-savannah-support/git-link.el#L110) since cgit instances don't necessarily have an username part and even in savannah.gnu.org some projects live in the git root (for example: http://git.savannah.gnu.org/cgit/guix.git/)
