### PR TITLE
Allow subdomain git remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,26 +68,39 @@ Name of the remote branch to link to.
 
 ### Git Timemachine
 
-If [`git-timemachine-mode`](https://github.com/pidu/git-timemachine) is active `git-link` generates a URL for the version of the file being visited.
+If [`git-timemachine-mode`](https://github.com/pidu/git-timemachine)
+is active `git-link` generates a URL for the version of the file being
+visited.
 
 ### Building Links and Adding Services
 
-`git-link-remote-alist` and `git-link-commit-remote-alist` map remotes'
-hostnames to a function capable of creating a URL on that host. To add (or
-modify) how URLs are created for a given host add the appropriate function
-objects to these lists.
+`git-link-remote-alist` is an alist containing `(REGEXP FUNCTION)`
+elements. The FUNCTION creates URLs for file on remote host names that
+match the REGEXP. To add (or modify) how URLs are created for a given
+host, add appropriate elements to this list.
 
-If you use a self-hosted version of one of the supported services, you
-can configure the link function alists for the hostname at which that
-service is hosted.  For example, for a GitHub Enterprise instance at
-`github.example.com`, you could add the following to your `.emacs` file.
+As an example, one of the default elements in this alist is
+`("gitlab" git-link-gitlab)`. So the `git-link-gitlab` function
+will be used to create URLs to files in remotes that match the
+*regexp* `"gitlab"`.  That would cover common Gitlab host URLs like
+*"gitlab.com"*, *"gitlab.example.com"* and *"gitlab.example.org"*.
+
+`git-link-commit-remote-alist` is also an alist containing `(REGEXP
+FUNCTION)` elements. Here, the FUNCTION creates URLs to the commit
+pages, for remote hosts matching REGEXP.
+
+If you use a self-hosted version of one of the supported services, but
+your remote URL does match with the defaults, you can configure these
+link function alists.  For example, for a GitHub Enterprise instance
+at `gh.example.com`, you could add the following to your `.emacs`
+file:
 
     (eval-after-load 'git-link
       '(progn
         (add-to-list 'git-link-remote-alist
-          '("github.example.com" git-link-github))
+          '("gh\\.example\\.com" git-link-github))
         (add-to-list 'git-link-commit-remote-alist
-          '("github.example.com" git-link-commit-github))))
+          '("gh\\.example\\.com" git-link-commit-github))))
 
 The `git-link` signature is:
 

--- a/git-link.el
+++ b/git-link.el
@@ -5,6 +5,7 @@
 ;; Version: 0.5.0 (unreleased)
 ;; Keywords: git, vc, github, bitbucket, gitlab, convenience
 ;; URL: http://github.com/sshaw/git-link
+;; Package-Requires: ((cl-lib "0.6.1"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -88,6 +89,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'thingatpt)
 (require 'url-util)
 
@@ -107,18 +109,28 @@
   "If non-nil use the latest commit's hash in the link instead of the branch name.")
 
 (defvar git-link-remote-alist
-  '(("github.com"    git-link-github)
-    ("bitbucket.org" git-link-bitbucket)
-    ("gitorious.org" git-link-gitorious)
-    ("gitlab.com"    git-link-gitlab))
-  "Maps remote hostnames to a function capable of creating the appropriate file URL")
+  '(("github" git-link-github)
+    ("bitbucket" git-link-bitbucket)
+    ("gitorious" git-link-gitorious)
+    ("gitlab" git-link-gitlab))
+  "Alist containing (REGEXP FUNCTION) where REGEXP is used to
+match the remote host URL and FUNCTION is capable of creating the
+appropriate file URL.
+
+As an example, \"gitlab\" will match with both \"gitlab.com\" and
+\"gitlab.example.com\".")
 
 (defvar git-link-commit-remote-alist
-  '(("github.com"    git-link-commit-github)
-    ("bitbucket.org" git-link-commit-bitbucket)
-    ("gitorious.org" git-link-commit-gitorious)
-    ("gitlab.com"    git-link-commit-github))
-  "Maps remote hostnames to a function capable of creating the appropriate commit URL")
+  '(("github" git-link-commit-github)
+    ("bitbucket" git-link-commit-bitbucket)
+    ("gitorious" git-link-commit-gitorious)
+    ("gitlab" git-link-commit-github))
+  "Alist containing (REGEXP FUNCTION) where REGEXP is used to
+match the remote host URL and FUNCTION is capable of creating the
+appropriate commit URL.
+
+As an example, \"gitlab\" will match with both \"gitlab.com\" and
+\"gitlab.example.com\".")
 
 ;; Matches traditional URL and scp style:
 ;; https://example.com/ruby/ruby.git
@@ -180,6 +192,23 @@
     (if (or (null remote) (string= remote "."))
 	"origin"
       remote)))
+
+(defun git-link--handler (alist str)
+  "For an ALIST whose `car' (a regexp) matches STR, return cadr.
+
+The ALIST consists of (REGEXP FN) list elements.
+Valid ALISTs are `git-link-commit-remote-alist',`git-link-commit-alist'.
+
+For the first ALIST element whose REGEXP matches with STR, FN is
+returned.
+
+Return nil,
+- if STR does not match with REGEXP in any of the elements of ALIST, or
+- if STR is not a string"
+  (when (stringp str)
+    (cadr (cl-find-if (lambda (lst)
+                        (string-match-p (car lst) str))
+                      alist))))
 
 (defun git-link--relative-filename ()
   (let* ((filename (buffer-file-name))
@@ -325,11 +354,10 @@ Defaults to \"origin\"."
                       (region (git-link--get-region)))
                  (list remote (car region) (cadr region))))
   (let* ((remote-host (git-link--remote-host remote))
-	 (filename    (git-link--relative-filename))
-	 (branch      (git-link--branch))
-	 (commit      (git-link--commit))
-	 (handler     (cadr (assoc remote-host git-link-remote-alist))))
-
+	 (filename (git-link--relative-filename))
+	 (branch (git-link--branch))
+	 (commit (git-link--commit))
+	 (handler (git-link--handler git-link-remote-alist remote-host)))
     (cond ((null filename)
 	   (message "Not in a git repository with a working tree"))
 	  ((null remote-host)
@@ -360,8 +388,8 @@ Defaults to \"origin\"."
 
   (interactive (list (git-link--select-remote)))
   (let* ((remote-host (git-link--remote-host remote))
-	 (commit      (word-at-point))
-	 (handler     (cadr (assoc remote-host git-link-commit-remote-alist))))
+	 (commit (word-at-point))
+	 (handler (git-link--handler git-link-commit-remote-alist remote-host)))
     (cond ((null remote-host)
 	   (message "Remote `%s' is unknown or contains an unsupported URL" remote))
 	  ((not (string-match "[a-z0-9]\\{7,40\\}" (or commit "")))

--- a/git-link.el
+++ b/git-link.el
@@ -1,4 +1,4 @@
-;;; git-link.el --- Get the GitHub/Bitbucket/GitLab URL for a buffer location
+;;; git-link.el --- Get the GitHub/Bitbucket/GitLab URL for a buffer location -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013-2017 Skye Shaw and others
 ;; Author: Skye Shaw <skye.shaw@gmail.com>
@@ -27,11 +27,11 @@
 ;;; Commentary:
 
 ;; Create URLs for files and commits in GitHub/Bitbucket/GitLab/...
-;; repositories. `git-link' returns the URL for the current buffer's file
-;; location at the current line number or active region. `git-link-commit'
-;; returns the URL for a commit. URLs are added to the kill ring.
+;; repositories.  `git-link' returns the URL for the current buffer's file
+;; location at the current line number or active region.  `git-link-commit'
+;; returns the URL for a commit.  URLs are added to the kill ring.
 ;;
-;; With a prefix argument prompt for the remote's name. Defaults to "origin".
+;; With a prefix argument prompt for the remote's name.  Defaults to "origin".
 
 ;;; Change Log:
 
@@ -113,9 +113,10 @@
     ("bitbucket" git-link-bitbucket)
     ("gitorious" git-link-gitorious)
     ("gitlab" git-link-gitlab))
-  "Alist containing (REGEXP FUNCTION) where REGEXP is used to
-match the remote host URL and FUNCTION is capable of creating the
-appropriate file URL.
+  "Alist of host names and functions creating file links for those.
+Each element looks like (REGEXP FUNCTION) where REGEXP is used to
+match the remote's host name and FUNCTION is used to generate a link
+to the file on remote host.
 
 As an example, \"gitlab\" will match with both \"gitlab.com\" and
 \"gitlab.example.com\".")
@@ -125,9 +126,10 @@ As an example, \"gitlab\" will match with both \"gitlab.com\" and
     ("bitbucket" git-link-commit-bitbucket)
     ("gitorious" git-link-commit-gitorious)
     ("gitlab" git-link-commit-github))
-  "Alist containing (REGEXP FUNCTION) where REGEXP is used to
-match the remote host URL and FUNCTION is capable of creating the
-appropriate commit URL.
+  "Alist of host names and functions creating commit links for those.
+Each element looks like (REGEXP FUNCTION) where REGEXP is used to
+match the remote's host name and FUNCTION is used to generate a link
+to the commit on remote host.
 
 As an example, \"gitlab\" will match with both \"gitlab.com\" and
 \"gitlab.example.com\".")
@@ -303,7 +305,7 @@ Return nil,
 	  dirname
 	  commit))
 
-(defun git-link-gitorious (hostname dirname filename branch commit start end)
+(defun git-link-gitorious (hostname dirname filename _branch commit start _end)
   (format "https://%s/%s/source/%s:%s#L%s"
 	  hostname
 	  dirname
@@ -317,7 +319,7 @@ Return nil,
 	  dirname
 	  commit))
 
-(defun git-link-bitbucket (hostname dirname filename branch commit start end)
+(defun git-link-bitbucket (hostname dirname filename _branch commit start end)
   ;; ?at=branch-name
   (format "https://%s/%s/src/%s/%s#%s-%s"
 	  hostname
@@ -405,9 +407,9 @@ Defaults to \"origin\"."
 
 ;;;###autoload
 (defun git-link-homepage (remote)
-  "Create a URL for the current buffer's repository homepage.
-The URL will be added to the kill ring. If `git-link-open-in-browser'
-is non-`nil' also call `browse-url'."
+  "Create a URL for the current buffer's REMOTE repository homepage.
+The URL will be added to the kill ring.  If `git-link-open-in-browser'
+is non-nil also call `browse-url'."
 
   (interactive (list (git-link--select-remote)))
   (let ((remote-host (git-link--remote-host remote)))


### PR DESCRIPTION
**UPDATE (2017/02/18)**

The `git-link` and `git-commit-link` functions will now work even if the
remote-host is not exactly "gitlab.com", but something like "gitlab.COMPANY.com"
or "gitlab.COMPANY.org" or "gitlab.COMPANY.co.in".

This commits adds the use of `cl-loop` macro. If using emacs 24.x or newer,
this is in-built in emacs in `cl-macs` library (which is required by the `cl-lib`
library).

But for older emacs versions, the `cl-lib` library will be auto-installed from
GNU Elpa with the help of the Package-Requires line added in this commit:

    ;; Package-Requires: ((cl-lib "0.6.1"))