### PR TITLE
Relax the git-link-remote-regex to allow more valid links

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -120,10 +120,11 @@
 ;; https://example.com/ruby/ruby.git
 ;; git@example.org:sshaw_/customer_gender.git
 ;; git@example.com:22/foo/bar.git
+;; http://orgmode@orgmode.org/org-mode.git
 ;;
 ;; Wont work for git remotes that aren't services.
 ;; Consider using url-generic-parse-url, but that requires a URL with a scheme
-(defconst git-link-remote-regex "\\([-.[:word:]]+\\)\\(?:/\\|:[0-9]*/?\\)\\([^/]+/[^/]+?\\)\\(?:\\.git\\)?$")
+(defconst git-link-remote-regex "\\([-.[:word:]]+\\)\\(?:/\\|:[0-9]*/?\\)\\([^/]+\\(?:/[^/]+?\\)*\\)\\(?:\\.git\\)?$")
 
 (defun git-link--exec(&rest args)
   (ignore-errors (apply 'process-lines `("git" ,@(when args args)))))


### PR DESCRIPTION
This changes a minor portion of `git-link-remote-regex` as follows:

```
     Before: "\\([^/]+/[^/]+?\\)"
     After:  "\\([^/]+\\(?:/[^/]+?\\)*\\)".
```

Earlier this regexp did not match "http://orgmode@orgmode.org/org-mode.git".

Now it does; without breaking the match for links containing 2 forward-slashes
as usual too -- "https://git.savannah.gnu.org/r/emacs.git"