### PR TITLE
Fix regexp for commit hash; support uppercase hash too

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -394,7 +394,7 @@ Defaults to \"origin\"."
 	 (handler (git-link--handler git-link-commit-remote-alist remote-host)))
     (cond ((null remote-host)
 	   (message "Remote `%s' is unknown or contains an unsupported URL" remote))
-	  ((not (string-match "[a-z0-9]\\{7,40\\}" (or commit "")))
+	  ((not (string-match-p "[a-fA-F0-9]\\{7,40\\}" (or commit "")))
 	   (message "Point is not on a commit hash"))
 	  ((not (functionp handler))
 	   (message "No handler for %s" remote-host))


### PR DESCRIPTION
Commit hash is a hexadecimal code -- 0..9, a..f

Also support commit hash in upper case.

Use `string-match-p` instead of `string-match` as the regexp
comparison is done just for boolean check.