### PR TITLE
Use commit when branch is empty

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -423,7 +423,10 @@ Defaults to \"origin\"."
 		     remote-host
 		     (git-link--remote-dir remote)
 		     filename
-		     (if (or (git-link--using-git-timemachine) git-link-use-commit)
+		     (if (or
+		          (null branch)
+		          (git-link--using-git-timemachine)
+		          git-link-use-commit)
 			 nil
 		       (url-hexify-string branch))
 		     commit


### PR DESCRIPTION
Pass `nil` to the link builder if the branch could not be determined.

`git-link--branch` returns `nil` when it cannot not determine the current branch.  However, `url-hexify-string` was converting `nil` to the empty string.  Consequently, some link handlers were using the empty string as the branch name instead of falling back to the commit.