### PR TITLE
Strip suffix on remote path only if it ends in .git

### DIFF
--- a/git-link-test.el
+++ b/git-link-test.el
@@ -25,5 +25,8 @@
   (should (equal '("orgmode.org" "org-mode")
                  (git-link--parse-remote "https://orgmode.org/org-mode.git")))
 
+  (should (equal '("gitlab.com" "weshmashian/emacs.d")
+                 (git-link--parse-remote "https://gitlab.com/weshmashian/emacs.d")))
+
   (should (equal '("foo-bar.github.com" "sshaw/foo/x")
                  (git-link--parse-remote "https://user:password@foo-bar.github.com/sshaw/foo/x.git")))

--- a/git-link.el
+++ b/git-link.el
@@ -302,7 +302,11 @@ return (FILENAME . REVISION) otherwise nil."
     (when host
       (when (and (not (string= "/" path))
                  (not (string= ""  path)))
-        (setq path (substring (file-name-sans-extension path) 1)))
+        (setq path (substring
+                    (if (string-suffix-p ".git" path)
+                        (file-name-sans-extension path)
+                      path)
+                    1)))
 
       ;; Fix-up scp style URLs
       (when (string-match ":" host)


### PR DESCRIPTION
Updated tests to reflect this.