### PR TITLE
git-link should work with magit-blame buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ If [`git-timemachine-mode`](https://gitlab.com/pidu/git-timemachine)
 is active `git-link` generates a URL for the version of the file being
 visited.
 
+### Magit-blame
+
+If [`magit-blame-mode`](https://magit.vc/manual/magit/Blaming.html) is active
+`git-link` generates a URL for the current active chunk of the file being
+visited.
+
 ### Building Links and Adding Services
 
 `git-link-remote-alist` is an alist containing `(REGEXP FUNCTION)`


### PR DESCRIPTION
Hey, first of all, thanks for your work on this package, it's incredibly helpful.

So, I wrote some code to make this package return a github blame URL in case the user is in magit-blame-mode. I haven't really tried it with other hosts/handlers, but I believe it should work as-is, provided they work with commits and line numbers.