### PR TITLE
Sourcegraph support

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -173,7 +173,8 @@
     ("bitbucket" git-link-bitbucket)
     ("gitorious" git-link-gitorious)
     ("gitlab" git-link-gitlab)
-    ("visualstudio\\|azure" git-link-azure))
+    ("visualstudio\\|azure" git-link-azure)
+    ("sourcegraph" git-link-sourcegraph))
   "Alist of host names and functions creating file links for those.
 Each element looks like (REGEXP FUNCTION) where REGEXP is used to
 match the remote's host name and FUNCTION is used to generate a link
@@ -190,7 +191,8 @@ As an example, \"gitlab\" will match with both \"gitlab.com\" and
     ("bitbucket" git-link-commit-bitbucket)
     ("gitorious" git-link-commit-gitorious)
     ("gitlab" git-link-commit-github)
-    ("visualstudio\\|azure" git-link-commit-azure))
+    ("visualstudio\\|azure" git-link-commit-azure)
+    ("sourcegraph" git-link-commit-sourcegraph))
   "Alist of host names and functions creating commit links for those.
 Each element looks like (REGEXP FUNCTION) where REGEXP is used to
 match the remote's host name and FUNCTION is used to generate a link
@@ -493,6 +495,27 @@ return (FILENAME . REVISION) otherwise nil."
 	  hostname
 	  dirname
 	  commit))
+
+(defun git-link-sourcegraph (hostname dirname filename branch commit start end)
+  (let ((line-or-range (cond ((and start end) (format "#L%s-%s" start end))
+                             (start (format "#L%s" start))
+                             (t "")))
+        (branch-or-commit (or branch commit))
+        (dir-file-name (directory-file-name dirname)))
+    (format "https://%s/%s@%s/-/blob/%s%s"
+            hostname
+            dir-file-name
+            branch-or-commit
+            filename
+            line-or-range)))
+
+(defun git-link-commit-sourcegraph (hostname dirname commit)
+  (let ((dir-file-name (directory-file-name dirname)))
+    (format "https://%s/%s/-/commit/%s"
+            hostname
+            dir-file-name
+            commit)))
+
 
 (defun git-link--select-remote ()
   (if current-prefix-arg


### PR DESCRIPTION
Not sure this is something that would be an addition to git-link as sourcegraph does not actually implement a repository, but it is related to git.

Sourcegraph allows to reference files by git commit or branch, even so it does not represent a git repository it can be useful to open files in sourcegraph instead of the remote.

This requires a pseudo remote to be setup in the `.git/config` of the project.

```
[remote "sourcegraph"]
  url = https://my.sourcegraph.host/my.git.host/my-repository
[git-link]
  remote = sourcegraph
```