### PR TITLE
[Savannah] Prevent extra "/git" appearing in M-x git-link

### DIFF
--- a/git-link-test.el
+++ b/git-link-test.el
@@ -50,4 +50,10 @@
                  (git-link--parse-remote "git://git.sv.gnu.org/emacs.git")))
 
   (should (equal '("git.savannah.gnu.org" "emacs")
+                 (git-link--parse-remote "https://git.savannah.gnu.org/git/emacs.git")))
+
+  (should (equal '("git.savannah.gnu.org" "emacs")
+                 (git-link--parse-remote "ssh://git.savannah.gnu.org/srv/git/emacs.git")))
+
+  (should (equal '("git.savannah.gnu.org" "emacs")
                  (git-link--parse-remote "git://git.savannah.gnu.org/emacs.git"))))

--- a/git-link.el
+++ b/git-link.el
@@ -394,6 +394,13 @@ return (FILENAME . REVISION) otherwise nil."
                     "\\1/_git/"
                     path)))
 
+      ;; For Savannah
+      (when (string= "git.savannah.gnu.org" host)
+        (cond
+         ((string-match "\\`git/" path)
+          (setq path (substring path 4)))
+         ((string-match "\\`srv/git/" path)
+          (setq path (substring path 8)))))
 
       (list host path))))
 


### PR DESCRIPTION
Prior to this patch, (cadr (git-link--parse-remote remote-url)) for
the Emacs repo would look like "git/emacs" instead of "emacs".