### PR TITLE
Get filename from base-buffer when in an indirect buffer

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -330,7 +330,7 @@ return (FILENAME . REVISION) otherwise nil."
 (defvar magit-buffer-file-name)
 
 (defun git-link--relative-filename ()
-  (let* ((filename (buffer-file-name))
+  (let* ((filename (buffer-file-name (buffer-base-buffer)))
 	 (dir      (git-link--repo-root)))
 
     (when (null filename)


### PR DESCRIPTION
Hi there,

This is a quick PR to fix the creation of links in indirect buffer.

I’ll use the opportunity to thank you for your work on this package. :)