### PR TITLE
Adding handler for codeberg.org

### DIFF
--- a/git-link-test.el
+++ b/git-link-test.el
@@ -31,6 +31,9 @@
   (should (equal '("gitlab.com" "weshmashian/emacs.d")
                  (git-link--parse-remote "https://gitlab.com/weshmashian/emacs.d")))
 
+  (should (equal '("codeberg.org" "takeonrules/emacs.d")
+                 (git-link--parse-remote "https://codeberg.org/takeonrules/emacs.d")))
+
   (should (equal '("foo-bar.github.com" "sshaw/foo/x")
                  (git-link--parse-remote "https://user:password@foo-bar.github.com/sshaw/foo/x.git")))
 

--- a/git-link.el
+++ b/git-link.el
@@ -195,6 +195,7 @@ See its docs."
 
 (defcustom git-link-remote-alist
   '(("git.sr.ht" git-link-sourcehut)
+    ("codeberg.org" git-link-codeberg)
     ("github" git-link-github)
     ("bitbucket" git-link-bitbucket)
     ("gitorious" git-link-gitorious)
@@ -214,6 +215,7 @@ As an example, \"gitlab\" will match with both \"gitlab.com\" and
 
 (defcustom git-link-commit-remote-alist
   '(("git.sr.ht" git-link-commit-github)
+    ("codeberg.org" git-link-commit-codeberg)
     ("github" git-link-commit-github)
     ("bitbucket" git-link-commit-bitbucket)
     ("gitorious" git-link-commit-gitorious)
@@ -457,6 +459,18 @@ return (FILENAME . REVISION) otherwise nil."
   (when git-link-open-in-browser
     (browse-url link)))
 
+(defun git-link-codeberg (hostname dirname filename branch commit start end)
+    (format "https://%s/%s/src/%s/%s"
+	    hostname
+	    dirname
+	    (or branch commit)
+            (concat filename
+                    (when start
+                      (concat "#"
+                              (if end
+                                  (format "L%s-%s" start end)
+                                (format "L%s" start)))))))
+
 (defun git-link-gitlab (hostname dirname filename branch commit start end)
   (format "https://%s/%s/blob/%s/%s"
 	  hostname
@@ -516,6 +530,12 @@ return (FILENAME . REVISION) otherwise nil."
 
       ;; Azure only supports full 32 characters SHA
       (car (git-link--exec "rev-parse" commit))))
+
+(defun git-link-commit-codeberg (hostname dirname commit)
+    (format "https://%s/%s/commit/%s"
+	    hostname
+	    dirname
+	    commit))
 
 (defun git-link-gitorious (hostname dirname filename _branch commit start _end)
   (format "https://%s/%s/source/%s:%s#L%s"


### PR DESCRIPTION
codeberg.org uses the 'src' slug instead of 'blob' like Github.  This
commit helps produce the correct URL for Codeberg.