### PR TITLE
URL escape special chars in pathnames

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -715,7 +715,7 @@ Defaults to \"origin\"."
                 (funcall handler
                          (car remote-info)
                          (cadr remote-info)
-                         filename
+                         (url-hexify-string filename (cons ?/ url-unreserved-chars))
                          (if (or (git-link--using-git-timemachine)
                                  (git-link--using-magit-blob-mode)
                                  vc-revison


### PR DESCRIPTION
I occasionally have to work on a project with whitespace in pathnames, which causes git-link to produce broken links. This change should fix that and other edge cases where problematic characters occur.