### PR TITLE
Do explicit url--allowed-chars for second url-hexify-string argument

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -759,7 +759,7 @@ Defaults to \"origin\"."
                 (funcall handler
                          (car remote-info)
                          (cadr remote-info)
-                         (url-hexify-string filename (cons ?/ url-unreserved-chars))
+                         (url-hexify-string filename (url--allowed-chars (cons ?/ url-unreserved-chars)))
                          (if (or (git-link--using-git-timemachine)
                                  (git-link--using-magit-blob-mode)
                                  vc-revison


### PR DESCRIPTION
Passing this argument as list is only supported since Emacs 27.0.90 (when bug#26469 was implemented), so we need to do an explicit conversion to a vector to keep to support older versions. The helper function url--allowed-chars is available since url-hexify-string allows the second argument, which is since Emacs 24.2.90. That should be early enough for all versions in common use today.

I tested this locally and it still works fine for my Emacs 28.0.50. 