### PR TITLE
Add support for googlesource.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Name of the remote branch to link to.
 * [GitHub](http://github.com)
 * [GitLab](https://gitlab.com)
 * [Gitorious](http://gitorious.org)
+* [GoogleSource](https://googlesource.com)
 * [Savannah](https://git.savannah.gnu.org/cgit)
 * [Sourcegraph](https://sourcegraph.com)
 * [sourcehut](https://sourcehut.org)

--- a/git-link-test.el
+++ b/git-link-test.el
@@ -62,4 +62,7 @@
                  (git-link--parse-remote "git://git.savannah.gnu.org/emacs.git")))
 
   (should (equal '("us-west-2.console.aws.amazon.com" "codesuite/codecommit/repositories/TestRepo")
-                 (git-link--parse-remote "ssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/TestRepo"))))
+                 (git-link--parse-remote "ssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/TestRepo")))
+
+  (should (equal '("go.googlesource.com" "go")
+                 (git-link--parse-remote "https://go.googlesource.com/go"))))

--- a/git-link.el
+++ b/git-link.el
@@ -214,6 +214,7 @@ See its docs."
     ("gitorious" git-link-gitorious)
     ("gitlab" git-link-gitlab)
     ("git\\.\\(sv\\|savannah\\)\\.gnu\\.org" git-link-savannah)
+    ("googlesource.com" git-link-googlesource)
     ("visualstudio\\|azure" git-link-azure)
     ("sourcegraph" git-link-sourcegraph)
     ("\\(amazonaws\\|amazon\\)\\.com" git-link-codecommit))
@@ -235,6 +236,7 @@ As an example, \"gitlab\" will match with both \"gitlab.com\" and
     ("gitorious" git-link-commit-gitorious)
     ("gitlab" git-link-commit-github)
     ("git\\.\\(sv\\|savannah\\)\\.gnu\\.org" git-link-commit-savannah)
+    ("googlesource.com" git-link-commit-googlesource)
     ("visualstudio\\|azure" git-link-commit-azure)
     ("sourcegraph" git-link-commit-sourcegraph)
     ("\\(amazonaws\\|amazon\\)\\.com" git-link-commit-codecommit))
@@ -255,6 +257,7 @@ As an example, \"gitlab\" will match with both \"gitlab.com\" and
     ("gitorious" git-link-homepage-github)
     ("gitlab" git-link-homepage-github)
     ("git\\.\\(sv\\|savannah\\)\\.gnu\\.org" git-link-homepage-savannah)
+    ("googlesource.com" git-link-homepage-github)
     ("visualstudio\\|azure" git-link-homepage-github)
     ("sourcegraph" git-link-homepage-github)
     ("\\(amazonaws\\|amazon\\)\\.com" git-link-homepage-codecommit))
@@ -549,6 +552,16 @@ return (FILENAME . REVISION) otherwise nil."
                                 (format "L%s-L%s" start end)
                               (format "L%s" start)))))))
 
+(defun git-link-googlesource (hostname dirname filename branch commit start end)
+  (format "https://%s/%s/+/%s/%s"
+	  hostname
+	  dirname
+	  (or branch commit)
+	  (concat filename
+                  (when start
+                    (format "#%s" start)
+                    ))))
+
 (defun git-link-azure (hostname dirname filename branch commit start end)
   (format "https://%s/%s?path=%%2F%s&version=%s&line=%s&lineEnd=%s&lineStartColumn=1&lineEndColumn=9999&lineStyle=plain"
 	  hostname
@@ -576,6 +589,12 @@ return (FILENAME . REVISION) otherwise nil."
 	  hostname
 	  dirname
 	  commit))
+
+(defun git-link-commit-googlesource (hostname dirname commit)
+  (format "https://%s/%s/+/%s"
+	  hostname
+	  dirname
+          commit))
 
 (defun git-link-commit-azure (hostname dirname commit)
  (format "https://%s/%s/commit/%s"


### PR DESCRIPTION
~~Resolves: https://github.com/sshaw/git-link/issues/100~~
(**Update:** this doesn't actually provide support for gitiles, and is limited to googelsource)

Also adds support for the repos hosted by `googlesource.com`, which I believe are all using gitiles. Such as https://android.googlesource.com/ and https://go.googlesource.com/go
I checked several projects under https://opensource.google/projects, and I believe all repos under the `googlesource.com` domain are using gitiles.

### Testing

I added a test to `git-link-test.el` to ensure the behavior of `git-link--parse-remote-test` was correct.

For the rest of the behavior, I ran the following tests manually, since I didn't see any existing automated tests (although it seems like the project can use some unit tests here):

#### `git-link`
I tested this by running `git-link` in several gitiles repos. 
The following value is copies to my clipboard:
1. with `git-link-use-commit` set to `t`: https://go.googlesource.com/go/+/38cfb3be9d486833456276777155980d1ec0823e/src/go/token/token.go#162
2. with `git-link-use-commit` set to `nil` (the default vaue): https://go.googlesource.com/go/+/master/src/go/token/token.go#162

#### `git-link-commit`
I tested this by running `git-link-commit` over some code like `// 38cfb3be9d486833456276777155980d1ec0823e` and got this:
https://go.googlesource.com/go/+/38cfb3be9d486833456276777155980d1ec0823e

#### `git-link-homepage`
Running `git-link-homepage` copies this to my clipboard: https://go.googlesource.com/go