### PR TITLE
Allow overriding git-link-use-commit when calling git-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Functions can be called interactively (`M-x git-link`) or via a key binding of y
 (global-set-key (kbd "C-c g l") 'git-link)
 ```
 
-With a prefix argument prompt for the remote's name. Defaults to `"origin"`.
+With a single prefix argument prompt for the remote's name. Defaults to `"origin"`.
+
+With a double prefix argument invert the value of `git-link-use-commit`.
 
 With a prefix argument of `-`, generate a link without line numbers.
 

--- a/git-link.el
+++ b/git-link.el
@@ -734,7 +734,7 @@ return (FILENAME . REVISION) otherwise nil."
   'git-link-homepage-svannah 'git-link-homepage-savannah "cf947f9")
 
 (defun git-link--select-remote ()
-  (if current-prefix-arg
+  (if (equal '(4) current-prefix-arg)
       (git-link--read-remote)
     (git-link--remote)))
 
@@ -755,8 +755,11 @@ or active region. The URL will be added to the kill ring.  If
 With a prefix argument of - generate a link without line number(s).
 Also see `git-link-use-single-line-number'.
 
-With any other prefix argument prompt for the remote's name.
-Defaults to \"origin\"."
+With a single prefix argument prompt for the remote's name.
+Defaults to \"origin\".
+
+With a double prefix argument invert the value of
+`git-link-use-commit'."
   (interactive
    (if (equal '- current-prefix-arg)
        (list (git-link--remote) nil nil)
@@ -799,7 +802,9 @@ Defaults to \"origin\"."
                          (if (or (git-link--using-git-timemachine)
                                  (git-link--using-magit-blob-mode)
                                  vc-revison
-                                 git-link-use-commit)
+                                 (if (equal '(16) current-prefix-arg)
+                                     (not git-link-use-commit)
+                                   git-link-use-commit))
                              nil
                            (url-hexify-string branch))
                          commit


### PR DESCRIPTION
Hi,

I personally tend to prefer setting `git-link-use-commit` to `t` globally, but in some cases, when calling `git-link`, I'd love to be able to temporarily change the value of `git-link-use-commit` to `nil` so the generated link points to the checked out branch instead of to the commit hash. I have a function like this in my config:

``` emacs-lisp
(defun my/git-link-branch ()
    "Create a URL representing the current buffer's location always
using the branch name."
    (interactive)
    (let ((git-link-use-commit nil))
      (call-interactively #'git-link)))
```

However it'd be cooler and more convenient if it was possible to "request" this behaviour when calling `git-link`.

This patch changes a little bit the semantics of the prefix argument, using a single prefix argument to select the remote (trying to make this interface change not hugely painful for users) and adding a double prefix argument to flip the current value of `git-link-use-commit` (only in the context of the current call to `git-link`, of course).

With this change applied, instead of having to maintain my own function like above, I'd only have to call:

```
C-u C-u M-x git-link RET
```

To generate a link to the file pointing to the current branch 😇

It'd be totally acceptable also to make this new feature cumulative with double prefix argument meaning then "select remote" **and** "invert `git-link-use-commit`".

Thanks for considering the patch.