### PR TITLE
Magit and Dired: fall back to current directory if not on file

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -391,12 +391,14 @@ return (FILENAME . REVISION) otherwise nil."
     (when (null filename)
       (cond
        ((eq major-mode 'dired-mode)
-        (setq filename (dired-file-name-at-point)))
+        (setq filename (or (dired-file-name-at-point)
+                           default-directory)))
        ((git-link--using-magit-blob-mode)
         (setq filename magit-buffer-file-name))
-       ((and (string-match-p "^magit-" (symbol-name major-mode))
-             (fboundp 'magit-file-at-point))
-        (setq filename (magit-file-at-point)))))
+       ((string-match-p "^magit-" (symbol-name major-mode))
+        (setq filename (or (and (fboundp 'magit-file-at-point)
+                                (magit-file-at-point))
+                           default-directory)))))
 
     (if (and dir filename
              ;; Make sure filename is not above dir, e.g. "/foo/repo-root/.."
@@ -797,6 +799,8 @@ With a double prefix argument invert the value of
              (message "Remote `%s' contains an unsupported URL" remote))
             ((not (functionp handler))
              (message "No handler found for %s" (car remote-info)))
+            ((equal filename "")
+             (git-link-homepage remote))
             ;; TODO: null ret val
             (t
              (let ((vc-revison (git-link--parse-vc-revision filename)))


### PR DESCRIPTION
This is most noticeable in magit-status, where you'd have to visit a random file to be able to jump to the repository page with git-link. In Dired, it's also noticeable if git-link is run when point isn't over a file, for instance on Dired's current directory heading.

This PR makes it so that, for example, running git-link in magit-status will fall back to visiting the repository at the current branch or commit. Then, as a special case, if current directory is project root (ie. `git-link--relative-filename` returns ""), visit the homepage instead.

Now git-link in Magit and Dired always goes somewhere sensible, instead of returning an error.

#### Before

- It works in an ordinary file
- "Cannot figure out what to link to" on the Dired header
- "Cannot figure out what to link to" in magit-status
- Can link to file under point in Dired

https://user-images.githubusercontent.com/11722318/228342018-2d653c35-1431-4170-bb35-48307991ccec.mp4

#### After

- It works in an ordinary file
- Can link to file under point in Dired
- Links to repository homepage instead in Dired when file under point is `..`
- ...or when on the Dired header.
- Links to repository homepage in magit-status

https://user-images.githubusercontent.com/11722318/228342537-5049cb9d-fbdb-410f-9b2d-f9b3aab4d9e6.mp4