### PR TITLE
Ability to resolve using OpenSSH client configuration file

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -214,6 +214,11 @@ See its docs."
   :type 'boolean
   :group 'git-link)
 
+(defcustom git-link-consider-ssh-config nil
+  "Consider ssh configuration file for resolving hostnames."
+  :type 'boolean
+  :group 'git-link)
+
 (defcustom git-link-remote-alist
   '(("git.sr.ht" git-link-sourcehut)
     ("codeberg.org" git-link-codeberg)
@@ -431,9 +436,15 @@ return (FILENAME . REVISION) otherwise nil."
       (when (string-match ":" host)
         (let ((parts (split-string host ":" t))
               (case-fold-search t))
-          (string-match (concat (car parts) ":\\(" (cadr parts) "\\)/") url)
+          (string-match (concat (regexp-quote (car parts)) ":\\(" (cadr parts) "\\)/") url)
           (setq host (car parts)
                 path (concat (match-string 1 url) "/" path))))
+
+
+      (when git-link-consider-ssh-config
+	(let* ((ssh-resolved-host (git-link--ssh-resolve-hostname host)))
+	  (when ssh-resolved-host
+	    (setq host ssh-resolved-host))))
 
       ;; Fix-up Azure SSH URLs
       (when (string= "ssh.dev.azure.com" host)
@@ -470,6 +481,15 @@ return (FILENAME . REVISION) otherwise nil."
                              (substring path 9)))))
 
       (list host path))))
+
+(defun git-link--ssh-resolve-hostname (hostname)
+  "Resolve HOSTNAME using ssh client."
+  (let ((output (shell-command-to-string (format "ssh -G %s" hostname)))
+	(host nil))
+    (dolist (line (split-string output "\n"))
+      (when (string-match "^hostname \\(.*\\)" line)
+	(setq host (match-string 1 line))))
+    host))
 
 (defun git-link--using-git-timemachine ()
   (and (boundp 'git-timemachine-revision)


### PR DESCRIPTION
So I have this setup where I use a different github account and a different private key configured like this in my ~/.ssh/config

```
Host github+myorg
  IdentitiesOnly yes
  HostName github.com
  IdentityFile ~/.ssh/myorg_id_rsa
  ```

This PR provides the ability to support such configuration. I have disabled it by default since this is not a common setup most peoples have.