### PR TITLE
Only hexify branch name if it's not nil.

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -861,7 +861,9 @@ With a double prefix argument invert the value of
                                      (not git-link-use-commit)
                                    git-link-use-commit))
                              nil
-                           (url-hexify-string branch))
+                           (if branch
+                               (url-hexify-string branch)
+                             nil))
                          commit
                          start
                          end))))))))


### PR DESCRIPTION
When we pass the branch name through to the handler, we do this https://github.com/sshaw/git-link/blob/master/git-link.el#L864
that calls `url-hexify-string` on the branch, whether it's nil or not. Passing a `nil` branch through to it will give `""` which is truthy, which means that the `(or branch commit)` line in each of the handlers, e.g.: https://github.com/sshaw/git-link/blob/master/git-link.el#L594 will always evaluate to the truth-ey empty string `""` and will give an incorrect url.

Fix that by only calling `url-hexify-string` if the branch is non-nil already.