### PR TITLE
Chore/add bitbucket tests

### DIFF
--- a/git-link-test.el
+++ b/git-link-test.el
@@ -72,3 +72,20 @@
 
   (should (equal '("bitbucket.org" "atlassianlabs/atlascode")
                  (git-link--parse-remote "ssh://bitbucket.org:atlassianlabs/atlascode.git"))))
+
+(ert-deftest git-link-bitbucket ()
+  (should (equal "https://bitbucket.org/atlassian/atlascode/annotate/a-commit-hash/README.md#README.md-1"
+                 (git-link-bitbucket "bitbucket.org" "atlassian/atlascode" "README.md" "_branch" "a-commit-hash" 1 nil)))
+
+  (should (equal "https://bitbucket.org/atlassian/atlascode/annotate/a-commit-hash/README.md#README.md-1:33"
+                 (git-link-bitbucket "bitbucket.org" "atlassian/atlascode" "README.md" "_branch" "a-commit-hash" 1 33)))
+
+  (should (equal "https://bitbucket.org/atlassian/atlascode/src/a-commit-hash/.gitignore#.gitignore-1:33"
+                 (git-link-bitbucket "bitbucket.org" "atlassian/atlascode" ".gitignore" "_branch" "a-commit-hash" 1 33))))
+
+(ert-deftest git-link--should-render-via-bitbucket-annotate ()
+  (should (equal "annotate"
+                 (git-link--should-render-via-bitbucket-annotate "README.md")))
+
+  (should (equal "src"
+                 (git-link--should-render-via-bitbucket-annotate "a-cool-new-file.txt"))))

--- a/git-link-test.el
+++ b/git-link-test.el
@@ -65,4 +65,10 @@
                  (git-link--parse-remote "ssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/TestRepo")))
 
   (should (equal '("go.googlesource.com" "go")
-                 (git-link--parse-remote "https://go.googlesource.com/go"))))
+                 (git-link--parse-remote "https://go.googlesource.com/go")))
+
+  (should (equal '("bitbucket.org" "atlassianlabs/atlascode")
+                 (git-link--parse-remote "https://bitbucket.org/atlassianlabs/atlascode.git")))
+
+  (should (equal '("bitbucket.org" "atlassianlabs/atlascode")
+                 (git-link--parse-remote "ssh://bitbucket.org:atlassianlabs/atlascode.git"))))

--- a/git-link.el
+++ b/git-link.el
@@ -304,6 +304,15 @@ we can prevent that behaviour."
   :type 'list
   :group 'git-link)
 
+;; https://support.atlassian.com/bitbucket-cloud/docs/readme-content/#Extensions-and-Languages
+(defcustom git-link-extensions-rendered-via-bitbucket-annotate '("org" "md" "mkd" "mkdn" "mdown"
+                                                                 "markdown" "text" "rst" "textile"
+                                                                 "asciidoc")
+  "List of extensions that should be rendered via annotate else
+they will actually be rendered. We can prevent that behaviour."
+  :type 'list
+  :group 'git-link)
+
 (defun git-link--exec(&rest args)
   (ignore-errors
     (with-temp-buffer
@@ -678,9 +687,10 @@ return (FILENAME . REVISION) otherwise nil."
 
 (defun git-link-bitbucket (hostname dirname filename _branch commit start end)
   ;; ?at=branch-name
-  (format "https://%s/%s/src/%s/%s"
+  (format "https://%s/%s/%s/%s/%s"
           hostname
           dirname
+          (git-link--should-render-via-bitbucket-annotate filename)
           commit
           (if (string= "" (file-name-nondirectory filename))
               filename
@@ -799,6 +809,15 @@ to the list of extensions which generated link should be
 shown as a plain file"
   (let ((extension (or (file-name-extension filename) "")))
     (member (downcase extension) git-link-extensions-rendered-plain)))
+
+(defun git-link--should-render-via-bitbucket-annotate (filename)
+  "Check if the extension of the given filename belongs
+to the list of extensions which generated link should be
+shown via annotate in bitbucket."
+  (let ((extension (or (file-name-extension filename) "")))
+    (if (member (downcase extension) git-link-extensions-rendered-via-bitbucket-annotate)
+        "annotate"
+      "src")))
 
 ;;;###autoload
 (defun git-link (remote start end)


### PR DESCRIPTION
This implements #83 to enhance the generation of bitbucket.org links for markdown files.