### PR TITLE
Re-add transient menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ This defaults to `"sourcegraph"` but can be changed. See [Building Links and Add
 
 URLs with ports or an http scheme will not work. It's a trivial fix so if it's a problem for you please open an issue.
 
+### [Emacs Transient](https://www.gnu.org/software/emacs/manual/html_mono/transient.html) Support
+
+An optional Transient interface (magit-like menu) is provided via `git-link-transient.el`. To enable you need to have
+`transient` installed as a dependency.
+
+To enable `(require 'git-link-transient)` and call `git-link-dispatch` to show the menu.
+
+
 ### Building Links and Adding Services
 
 `git-link-remote-alist` is an alist containing `(REGEXP FUNCTION)`

--- a/git-link-transient.el
+++ b/git-link-transient.el
@@ -1,0 +1,128 @@
+;;; git-link-transient.el --- Transient interface for git-link  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2013-2024 Skye Shaw and others
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Transient interface (magit-like menu) for git-link.
+;; Call `git-link-dispatch' to show the menu.
+;;
+;; You need to have `transient' installed as a depenency.
+;; (it's not listed as the dependency of git-link because we want it to be optional.)
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'transient)
+(require 'git-link)
+
+(defun git-link-dispatch--action ()
+  "Finally call `git-link' with transient arguments."
+  (let* ((args (transient-args 'git-link-dispatch))
+         (git-link-default-branch (transient-arg-value "branch=" args))
+         (git-link-default-remote (transient-arg-value "remote=" args))
+         (git-link-use-commit (transient-arg-value "use_commit" args))
+         (git-link-use-single-line-number (transient-arg-value "line_number" args)))
+    (call-interactively #'git-link)))
+
+(defun git-link-dispatch--copy ()
+  "The copy command in transient suffix."
+  (interactive)
+  (let ((git-link-open-in-browser nil)
+        (git-link-add-to-kill-ring t))
+    (git-link-dispatch--action)))
+
+(defun git-link-dispatch--open ()
+  "The open command in transient suffix."
+  (interactive)
+  (let ((git-link-open-in-browser t))
+    (git-link-dispatch--action)))
+
+(defclass git-link--transient-bare-option (transient-option) ()
+  "Similar to `transient-option', but format without argument string.")
+
+(cl-defmethod transient-format ((obj git-link--transient-bare-option))
+  (format " %s %s (%s)"
+          (transient-format-key obj)
+          (transient-format-description obj)
+          (let ((v (oref obj value)))
+            (if (> (length v) 0)
+                (propertize v 'face 'transient-value)
+              (propertize "default" 'face 'transient-inactive-value)))))
+
+(defclass git-link--transient-bare-switch (transient-switch) ()
+  "Similar to `transient-switch', but format without argument string, only yes/no.")
+
+(cl-defmethod transient-format ((obj git-link--transient-bare-switch))
+  (format " %s %s (%s)"
+          (transient-format-key obj)
+          (transient-format-description obj)
+          (if (oref obj value)
+              (propertize "on" 'face 'transient-value)
+            (propertize "off" 'face 'transient-inactive-value))))
+
+(transient-define-infix git-link-dispatch--branch ()
+  :class git-link--transient-bare-option
+  :argument "branch="
+  :description "Branch"
+  :prompt "Branch: "
+  :key "b"
+  :init-value (lambda (obj) (oset obj value git-link-default-branch))
+  :reader (lambda (prompt &rest _)
+            (completing-read
+             prompt
+             (remove nil (list git-link-default-branch (git-link--branch))))))
+
+(transient-define-infix git-link-dispatch--remote ()
+  :class git-link--transient-bare-option
+  :argument "remote="
+  :description "Remote"
+  :key "r"
+  :init-value (lambda (obj) (oset obj value git-link-default-remote))
+  :reader (lambda (&rest _) (git-link--read-remote)))
+
+(transient-define-infix git-link-dispatch--use-commit ()
+  :class git-link--transient-bare-switch
+  :argument "use_commit"
+  ;; the value should be "use_commit" (the argument) or nil. not t
+  :init-value (lambda (obj) (oset obj value (and git-link-use-commit "use_commit")))
+  :description "Use commit"
+  :key "c")
+
+(transient-define-infix git-link-dispatch--line-number ()
+  :class git-link--transient-bare-switch
+  :argument "line_number"
+  :description "Line number"
+  :init-value (lambda (obj) (oset obj value (and git-link-use-single-line-number "line_number")))
+  :if-not 'use-region-p
+  :key "n")
+
+;;;###autoload
+(transient-define-prefix git-link-dispatch ()
+  "Git link dispatch."
+  [:description
+   "Options"
+   (git-link-dispatch--branch)
+   (git-link-dispatch--remote)
+   (git-link-dispatch--use-commit)
+   (git-link-dispatch--line-number)]
+  [:description
+   "Git link"
+   ("l" "Copy link" git-link-dispatch--copy)
+   ("o" "Open in browser" git-link-dispatch--open)])
+
+(provide 'git-link-transient)
+;;; git-link-transient.el ends here

--- a/git-link-transient.el
+++ b/git-link-transient.el
@@ -20,7 +20,7 @@
 ;; Transient interface (magit-like menu) for git-link.
 ;; Call `git-link-dispatch' to show the menu.
 ;;
-;; You need to have `transient' installed as a depenency.
+;; You need to have `transient' installed as a dependency.
 ;; (it's not listed as the dependency of git-link because we want it to be optional.)
 
 ;;; Code:

--- a/git-link-transient.el
+++ b/git-link-transient.el
@@ -110,7 +110,7 @@
   :if-not 'use-region-p
   :key "n")
 
-;;;###autoload
+;;;###autoload (autoload 'git-link-dispatch "git-link-transient" nil t)
 (transient-define-prefix git-link-dispatch ()
   "Git link dispatch."
   [:description


### PR DESCRIPTION
https://github.com/sshaw/git-link/pull/121 added a transient menu, but this did not work with any currently released versions of Emacs (https://github.com/sshaw/git-link/issues/129), so it was reverted.

I cherry-picked the two original commits, and added a third commit that fixes the issue (based on https://github.com/magit/transient/issues/280#issuecomment-2019214088) by adding `(autoload 'git-link-dispatch "git-link-transient" nil t)` to the autoload line. I cherry-picked the commits as I didn't want to take credit for anyone else's work, but let me know if you want it done differently.

This fixes the issue for me on 29.4.