### PR TITLE
Codeberg handler. format permalink correctly.

### DIFF
--- a/git-link-test.el
+++ b/git-link-test.el
@@ -181,7 +181,7 @@
                  (git-link-codeberg "https://codeberg.org" "user/repo" "file.txt" "master" "abc123" 10 20)))
 
   ;; File link with commit instead of branch
-  (should (equal "https://codeberg.org/user/repo/src/abc123/file.txt"
+  (should (equal "https://codeberg.org/user/repo/src/commit/abc123/file.txt"
                  (git-link-codeberg "https://codeberg.org" "user/repo" "file.txt" nil "abc123" nil nil))))
 
 

--- a/git-link.el
+++ b/git-link.el
@@ -606,16 +606,16 @@ is prepended to it."
       (concat "https://" web-host))))
 
 (defun git-link-codeberg (hostname dirname filename branch commit start end)
-    (format "%s/%s/src/%s/%s"
-	    hostname
-	    dirname
-	    (or branch commit)
-            (concat filename
-                    (when start
-                      (concat "#"
-                              (if end
-                                  (format "L%s-L%s" start end)
-                                (format "L%s" start)))))))
+  (format "%s/%s/src/%s/%s"
+	  hostname
+	  dirname
+          (or branch (concat "commit/" commit))
+          (concat filename
+                  (when start
+                    (concat "#"
+                            (if end
+                                (format "L%s-L%s" start end)
+                              (format "L%s" start)))))))
 
 (defun git-link-gitlab (hostname dirname filename branch commit start end)
   (format "%s/%s/-/blob/%s/%s"


### PR DESCRIPTION
Codeberg permalinks add `/commit/` after `/src` and before the commit hash. This PR makes `git-link` create correct permalinks to code references for Codeberg.

Currently, if you visit a `git-link` created commit URL in the browser, Forgejo/Codeberg will re-write it to add the `/commit/` part. I'm working on an emacs client for Forgejo (https://codeberg.org/martianh/fj.el), so I can't benefit from such re-writing and need `git-link` to create the right kind of permalink.