### PR TITLE
If in magit-revision buffer, git-link can open the commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,9 @@ For example:
 <img src="./magit-revision-buffer.png" width="400" alt="magit-revision buffer demo">
 
 Here one can get a link to:
-- The commit by calling `git-link-commit` on a commit hash
 - A file by calling `git-link` on a filename or within its diff
+- The commit by calling `git-link-commit` on a commit hash or anywhere in the
+  buffer (besides filename or its diff)
 
 ### Building Links and Adding Services
 

--- a/git-link.el
+++ b/git-link.el
@@ -951,15 +951,20 @@ Defaults to \"origin\"."
     (if (null remote-url)
         (message "Remote `%s' not found" remote)
 
+      (setq commit (word-at-point))
+      (when (and (not (string-match-p "[a-fA-F0-9]\\{7,40\\}" (or commit "")))
+                 (derived-mode-p 'magit-revision-mode)
+                 (functionp 'magit-buffer-revision))
+        (setq commit (magit-buffer-revision)))
+
       (setq remote-info (git-link--parse-remote remote-url)
             git-host (car remote-info)
-            commit (word-at-point)
             handler (git-link--handler git-link-commit-remote-alist git-host)
             web-host (git-link--web-host git-host))
 
       (cond ((null git-host)
              (message "Remote `%s' contains an unsupported URL" remote))
-            ((not (string-match-p "[a-fA-F0-9]\\{7,40\\}" (or commit "")))
+            ((not commit)
              (message "Point is not on a commit hash"))
             ((not (functionp handler))
              (message "No handler for %s" git-host))


### PR DESCRIPTION
I think this better than printing an error that

> Can't figure out what to link to

When in a `magit-revision` buffer, people most likely want to link the displayed commit. But this also allows to link a commit that the cursor is pointing to.