### PR TITLE
fix: git-link-homepage-remote-alist missing codeberg.org

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -287,6 +287,7 @@ As an example, \"gitlab\" will match with both \"gitlab.com\" and
 
 (defcustom git-link-homepage-remote-alist
   '(("git.sr.ht" git-link-homepage-github)
+    ("codeberg.org" git-link-homepage-codeberg)
     ("github" git-link-homepage-github)
     ("bitbucket" git-link-homepage-github)
     ("gitorious" git-link-homepage-github)


### PR DESCRIPTION
I noticed that the homepage-alist is missing `codeberg.org`. Not sure of the order, but did the same as the other two alists.

I use git-link togther with link-hint to quickly open my repo page in Magit status buffer.
``` elisp
'(link-hint-action-fallback-commands
	 '(:open
		 (lambda nil
			 (condition-case _
					 (progn (browse-url (git-link-homepage "origin")) t)
				 (error nil)))))```