### PR TITLE
Add `--no-show-signature' to git log args.

### DIFF
--- a/git-link.el
+++ b/git-link.el
@@ -366,7 +366,8 @@ If you want \\='http://\\=' instead prefix the host with it:
   (git-link--exec "remote"))
 
 (defun git-link--last-commit ()
-  (car (git-link--exec "--no-pager" "log" "-n1" "--pretty=format:%H")))
+  (car (git-link--exec
+        "--no-pager" "log" "-n1" "--no-show-signature" "--pretty=format:%H")))
 
 (defvar magit-buffer-revision)
 


### PR DESCRIPTION
When the `git log` output contains GPG signature info (which can happen e.g. when the user's `.gitconfig` has `showSignature = true`) it confuses the revision parser. Here we add an arg to `git log` to explicitly disable any GPG signature info.